### PR TITLE
adypm install bug

### DIFF
--- a/os/filesystem/cmd.js
+++ b/os/filesystem/cmd.js
@@ -476,7 +476,7 @@ async function pacman(arg) {
         let file = fs.createWriteStream(
           afs.fsfix(arg.dir.home) + ".adypm/tmp/" + num + ".json"
         );
-        let req = https.get(item.url + "repos/pkg.json", (res) => {
+        https.get(repo[0] + "repos/pkg.json", (res) => {
           res.pipe(file);
 
           // after download completed close filestream


### PR DESCRIPTION
`adypm +anything` will crash with
`ReferenceError: item is not defined`, looked in code and it appeared to be
```js
let req = https.get(item.url + "repos/pkg.json", (res) => {
``` 
at `os/filesystem/cmd.js:479`
I believe it was supposed to be 
```js
let req = https.get(repo[0] + "repos/pkg.json", (res) => {
```
side note, req is unused and can be removed into just
```js
https.get(repo[0] + "repos/pkg.json", (res) => {
```